### PR TITLE
added setOnProgress

### DIFF
--- a/src/curl.lib.js
+++ b/src/curl.lib.js
@@ -4,11 +4,16 @@ const Const = require('./constants');
 const Converter = require('iota.crypto.js').converter;
 const NONCE_TIMESTAMP_LOWER_BOUND = 0;
 const NONCE_TIMESTAMP_UPPER_BOUND = Converter.fromValue(0xffffffffffffffff);
-const MAX_TIMESTAMP_VALUE = (Math.pow(3,27) - 1) / 2 
+const MAX_TIMESTAMP_VALUE = (Math.pow(3,27) - 1) / 2
 
 let pdInstance;
+let onProgress;
 
-const pow = (options, success, error) => {  
+const setOnProgress = (fn) => {
+  onProgress = fn;
+}
+
+const pow = (options, success, error) => {
   let state;
 
   if ('trytes' in options) {
@@ -74,6 +79,9 @@ const overrideAttachToTangle = iota => {
           return callback(error)
         } else {
           i++
+          if(typeof onProgress !== 'undefined') {
+            onProgress(i);
+          }
           if (i < trytes.length) {
             loopTrytes()
           } else {
@@ -153,13 +161,14 @@ const overrideAttachToTangle = iota => {
 }
 
 window.curl = module.exports = {
-  init: () => { 
-    pdInstance = PearlDiver.instance(); 
+  init: () => {
+    pdInstance = PearlDiver.instance();
     if(pdInstance == null) {
       return false;
     }
     return true;
   },
+  setOnProgress,
   pow,
   prepare: PearlDiver.prepare,
   setOffset: (o) => {pdInstance.offset = o},


### PR DESCRIPTION
When using the overrided `addToTangle`, you can link yourself to this event to show the user some realtime progress. This is especially handy (ba dum tss) when you PoW multiple bundles at the same time.

Behaviour shouldn't change with this PR, but it's like 04:30 in the night over here so merge with caution :+1: 

Example:
```
curl.setOnProgress((i) => {
    this.powProgress = Math.min((i / parseFloat(preparedTransfers.length)), 1)
})
```