### PR TITLE
#29: add init() to README API documentation + example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ An example of the usage of curl.lib.js:
 
 ```
 var curl = require('curl.lib.js');
-var minWeight = 18;
+var myTryteString = 'FOOBAR9TRYTES';
+var minWeight = 14;
+curl.init();
 curl.pow({trytes: myTryteString, minWeight})
     .then((nonce) =>{
         console.log(myTryteString.substr(0, 2187-81).concat(nonce));
@@ -31,6 +33,8 @@ curl.pow({trytes: myTryteString, minWeight})
 ```
 
 Available functions:
+* `init()`
+    * initializes the curl object. must be called before doing proof of work!
 * `pow({trytes, minWeight})` 
     * gets the proof-of-work on a transaction 
     * possible errors:


### PR DESCRIPTION
as mentioned in #29, the init() was missing from the documentation